### PR TITLE
Fix for ImportError on runnning build.py

### DIFF
--- a/titanium.xcconfig
+++ b/titanium.xcconfig
@@ -10,7 +10,7 @@ TITANIUM_SDK_VERSION = 2.1.2.GA
 // 
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
-TITANIUM_SDK = /Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
+TITANIUM_SDK = $HOME/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
 TITANIUM_BASE_SDK = "$(TITANIUM_SDK)/iphone/include"
 TITANIUM_BASE_SDK2 = "$(TITANIUM_SDK)/iphone/include/TiCore"
 HEADER_SEARCH_PATHS= $(TITANIUM_BASE_SDK) $(TITANIUM_BASE_SDK2)


### PR DESCRIPTION
Hey! I was getting this error...

$ python build.py 
[WARN] please update the LICENSE file with your license text before distributing
Traceback (most recent call last):
  File "build.py", line 216, in <module>
    build_module(manifest,config)
  File "build.py", line 161, in build_module
    from tools import ensure_dev_path
ImportError: No module named tools

and adding $HOME in the xcconfig fixed it. Hope that helps!
